### PR TITLE
优化没有配置副标题时的主页标题显示

### DIFF
--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -32,7 +32,7 @@
 	<link rel="preconnect" href="//9qpuwspm.api.lncld.net">
 	<link rel="preconnect" href="//gravatar.loli.net">
 
-	<title>{% if title %}{{ title }}{% else %}{{ config.title }}{% endif %} | {% if is_home() %}{{ config.subtitle }}{% else %}{{ config.title }}{% endif %}</title>
+	<title>{% if title %}{{ title }}{% else %}{{ config.title }}{% endif %}{% if is_home() %}{% if config.subtitle %} | {{ config.subtitle }}{% endif %}{% else %} | {{ config.title }}{% endif %}</title>
 
 	<meta name="HandheldFriendly" content="True" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2"/>
@@ -64,7 +64,7 @@
 
 	<meta property="og:site_name" content="{{ config.title }}">
 	<meta property="og:type" content="{% if is_post() %}article{% else %}blog{% endif %}">
-	<meta property="og:title" content="{% if title %}{{ title }}{% else %}{{ config.title }}{% endif %} | {% if is_home() %}{{ config.subtitle }}{% else %}{{ config.title }}{% endif %}">
+	<meta property="og:title" content="{% if title %}{{ title }}{% else %}{{ config.title }}{% endif %}{% if is_home() %}{% if config.subtitle %} | {{ config.subtitle }}{% endif %}{% else %} | {{ config.title }}{% endif %}">
 	<meta property="og:description" content="{% if is_post() %}{{ page.description }}{% else %}{{ config.description }}{% endif %}">
 	<meta property="og:url" content="{{ config.url }}{{ url_for(page.path) }}">
 


### PR DESCRIPTION
在没有配置 Hexo 副标题时，现有版本仍会在主页的标题后添加分隔符。所以做了一点小小的修改来解决这个问题。😉